### PR TITLE
Add logback-classic and exclude slf4j-nop

### DIFF
--- a/resources/leiningen/new/kraken/project.clj
+++ b/resources/leiningen/new/kraken/project.clj
@@ -9,7 +9,9 @@
                  [com.novemberain/langohr "3.2.0"]
                  [democracyworks/datomic-toolbox "1.0.0" :exclusions [com.datomic/datomic-pro]]
                  [prismatic/schema "0.4.3"]
-                 [com.datomic/datomic-pro "0.9.5153"]
+                 [com.datomic/datomic-pro "0.9.5153" :exclusions [org.slf4j/slf4j-nop
+                                                                  org.slf4j/slf4j-log4j12]]
+                 [ch.qos.logback/logback-classic "1.1.3"]
                  [org.immutant/core "2.0.1"]
                  [democracyworks/kehaar "0.3.0"]]
   :plugins [[lein-immutant "2.0.0"]]


### PR DESCRIPTION
We discovered that some libraries set the logger to nop and that's
bad. It means if we don't set the logger then we don't get any
logging. This solution is suggested in the [Datomic
Docs](http://docs.datomic.com/configuring-logging.html).
