### PR TITLE
Update kehaar dependency and use wire-up in queues.

### DIFF
--- a/resources/leiningen/new/kraken_works/project.clj
+++ b/resources/leiningen/new/kraken_works/project.clj
@@ -13,7 +13,7 @@
                                                                   org.slf4j/slf4j-log4j12]]
                  [ch.qos.logback/logback-classic "1.1.3"]
                  [org.immutant/core "2.0.1"]
-                 [democracyworks/kehaar "0.3.0"]]
+                 [democracyworks/kehaar "0.4.0"]]
   :plugins [[lein-immutant "2.0.0"]]
   :main ^:skip-aot {{name}}.core
   :target-path "target/%s"


### PR DESCRIPTION
Kehaar just released 0.4.0 with the wire-up helpers. New kraken services should use the new kehaar and wire-up pattern, because it's way easier to read and write.
