### PR TITLE
Summer cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A Leiningen template for calling forth a new kraken-works component project from the
 deep.
 
-This is used for microservices that speak [RabbitMQ](https://www.rabbitmq.com/) (via [Kehaar](https://github.com/democracyworks/kehaar)), use [Datomic](http://www.datomic.com), and deploy to [WildFly](http://wildfly.org).
+This is used for microservices that speak [RabbitMQ](https://www.rabbitmq.com/) (via [Kehaar](https://github.com/democracyworks/kehaar)), and use [Datomic](http://www.datomic.com).
 
 ## Usage
 

--- a/resources/leiningen/new/kraken_works/README.md
+++ b/resources/leiningen/new/kraken_works/README.md
@@ -74,7 +74,7 @@ automate building and deploying to CoreOS.
 
 ## License
 
-Copyright © 2015 Democracy Works, Inc.
+Copyright © 2017 Democracy Works, Inc.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/resources/leiningen/new/kraken_works/docker-compose.yml
+++ b/resources/leiningen/new/kraken_works/docker-compose.yml
@@ -4,31 +4,20 @@ services:
     build: .
     depends_on:
       - rabbitmq
-      - wildfly
     environment:
       RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
       RABBITMQ_PORT_5672_TCP_PORT: "5672"
       DATOMIC_URI: "datomic:dev://datomic:4334/{{name}}"
-      WILDFLY_PORT_9990_TCP_ADDR: wildfly
-      WILDFLY_PORT_9990_TCP_PORT: "9990"
-      WILDFLY_ENV_ADMIN_USERNAME: admin
-      WILDFLY_ENV_ADMIN_PASSWORD: admin
-  wildfly:
-    image: quay.io/democracyworks/wildfly:9.0.2.Final-debug
-    depends_on:
-      - rabbitmq
-      - datomic
-    ports:
-      - "59990:9990"
-      - "58080:8080"
-    environment:
-      ADMIN_USERNAME: admin
-      ADMIN_PASSWORD: admin
   datomic:
-    image: quay.io/democracyworks/datomic-tx:0.9.5394
+    image: quay.io/democracyworks/datomic-tx:0.9.5544
+    ports:
+      - "4334:4334"
+      - "4335:4335"
+      - "4336:4336"
+    environment:
+      ALT_HOST: localhost
   rabbitmq:
-    image: rabbitmq:3.6.2-management
+    image: rabbitmq:3.6.9-management
     ports:
       - "45672:5672"
       - "55672:15672"
-    hostname: rabbitmq


### PR DESCRIPTION
- Remove Wildfly from docker-compose.yml
- Remove unnecessary `hostname` configuration
  - This will be set to the service name by default, so no need to specify it
    again.
- Bump versions
- Expose interesting Datomic ports by default
  - This might help during development, following the rationale that the
    RabbitMQ ports are also exposed by default.