### PR TITLE
Switch systemd `Requires=` to `Wants=` to avoid terminal failures

### DIFF
--- a/resources/leiningen/new/kraken_works/PROJECT@.service.template
+++ b/resources/leiningen/new/kraken_works/PROJECT@.service.template
@@ -5,7 +5,7 @@ Requires=docker.service
 After=consul@%i.service
 Wants=consul@%i.service
 After=rabbitmq@%i.service
-Requires=rabbitmq@%i.service
+Wants=rabbitmq@%i.service
 
 [Service]
 EnvironmentFile=/etc/environment


### PR DESCRIPTION
Currently, the template uses a `Requires=` line to depend on RabbitMQ. Occasionally, RabbitMQ will fail to start around the same time as the `-works` component is starting, usually when a machine reboots and RabbitMQ may not initially start successfully (Consul/autoclustering may not be ready just yet, causing RabbitMQ to restart, etc.)

It is [recommended by the systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=) not to use `Requires=` if it is not strictly needed:

>Often, it is a better choice to use Wants= instead of Requires= in order to achieve a system that is more robust when dealing with failing services.

The main issue here is that the component will not automatically recover, and requires an operator to stop and start the failed service.

An example of logs generated when such an event is encountered:

```
-- Reboot --
Nov 30 23:13:25 ip-10-36-136-228 systemd[1]: Dependency failed for mail-scan-works.
Nov 30 23:13:25 ip-10-36-136-228 systemd[1]: mail-scan-works@1.service: Job mail-scan-works@1.service/start failed with result 'dependency'.
-- Reboot --
Dec 01 17:56:20 ip-10-36-136-228 systemd[1]: Dependency failed for mail-scan-works.
Dec 01 17:56:20 ip-10-36-136-228 systemd[1]: mail-scan-works@1.service: Job mail-scan-works@1.service/start failed with result 'dependency'.
```