### PR TITLE
Return the actual rmq-connection

### DIFF
--- a/resources/leiningen/new/kraken_works/queue.clj
+++ b/resources/leiningen/new/kraken_works/queue.clj
@@ -7,7 +7,7 @@
   (let [max-retries 5
         rmq-conn (kehaar.rabbitmq/connect-with-retries connection max-retries)
         kehaar-resources (kehaar/init! rmq-conn kehaar)]
-    {:connections [connection]
+    {:connections [rmq-conn]
      :kehaar-resources kehaar-resources}))
 
 (defn close-resources! [resources]


### PR DESCRIPTION
This line was missed in an earlier change. `rmq/closed?` and `rmq/close` expect the rmq connection itself, not the connection info, so `close-resources!` throws when it is called.