### PR TITLE
Update deps and docker compose

### DIFF
--- a/resources/leiningen/new/kraken_works/docker-compose.yml
+++ b/resources/leiningen/new/kraken_works/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 {{#datomic?}}
       DATOMIC_URI: "datomic:dev://datomic:4334/{{name}}"
   datomic:
-    image: quay.io/democracyworks/datomic-tx:0.9.5544
+    image: quay.io/democracyworks/datomic-tx:0.9.5703
     ports:
       - "4334:4334"
       - "4335:4335"

--- a/resources/leiningen/new/kraken_works/docker-compose.yml
+++ b/resources/leiningen/new/kraken_works/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
       RABBITMQ_PORT_5672_TCP_PORT: "5672"
 {{#datomic?}}
-      DATOMIC_URI: "datomic:dev://datomic:4334/{{name}}"
+      {{env-var-style}}_DATOMIC_URI: "datomic:dev://datomic:4334/{{name}}"
   datomic:
     image: quay.io/democracyworks/datomic-tx:0.9.5703
     ports:

--- a/resources/leiningen/new/kraken_works/project.clj
+++ b/resources/leiningen/new/kraken_works/project.clj
@@ -3,23 +3,22 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/tools.logging "0.4.1"]
                  [turbovote.resource-config "0.2.1"]
 {{#datomic?}}
-                 [democracyworks/datomic-toolbox "2.0.4"
+                 [democracyworks/datomic-toolbox "2.0.5"
                   :exclusions [com.datomic/datomic-pro]]
-                 [prismatic/schema "1.1.6"]
-                 [com.datomic/datomic-pro "0.9.5561"
+                 [com.datomic/datomic-pro "0.9.5703"
                   :exclusions [org.slf4j/slf4j-nop
                                org.slf4j/slf4j-log4j12]]
-                 [com.amazonaws/aws-java-sdk-dynamodb "1.11.128"
+                 [com.amazonaws/aws-java-sdk-dynamodb "1.11.402"
                   :exclusions [commons-codec commons-logging]]
 {{/datomic?}}
-                 [ch.qos.logback/logback-classic "1.2.2"]
-                 [democracyworks/kehaar "0.11.2"]]
+                 [ch.qos.logback/logback-classic "1.2.3"]
+                 [democracyworks/kehaar "0.11.4"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
-  :java-agents [[com.newrelic.agent.java/newrelic-agent "3.35.1"]]
+  :java-agents [[com.newrelic.agent.java/newrelic-agent "4.5.0"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}
   :prep-tasks ["javac" "compile" "jar-copier"]


### PR DESCRIPTION
These are the same changes as #21, but without the build script changes from #24, and with more up-to-date dependencies